### PR TITLE
Fix Dall3 timestamp deviation

### DIFF
--- a/Dall3.py
+++ b/Dall3.py
@@ -45,7 +45,7 @@ print("🚀 Extraction des frames via ffmpeg...")
 subprocess.run([
     "ffmpeg",
     "-i", VIDEO_PATH,
-    "-vf", f"fps={fps // FRAME_SKIP}",
+    "-vf", f"fps={fps / FRAME_SKIP}",
     os.path.join(TMP_IMG_DIR, "frame_%05d.jpg")
 ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 


### PR DESCRIPTION
## Summary
- make ffmpeg use the exact fractional frame rate when extracting frames

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854930afcd883299da6db51da1127fd